### PR TITLE
Add support for Risks in Sync API

### DIFF
--- a/src/DeepSecure.ThreatRemoval/Comms/IRequester.cs
+++ b/src/DeepSecure.ThreatRemoval/Comms/IRequester.cs
@@ -14,6 +14,15 @@ namespace DeepSecure.ThreatRemoval.Comms
 		/// <param name="file">File to be converted to safe version</param>
 		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
 		/// <returns>The converted file returned from the Deep Secure Threat Removal API</returns>
-		Task<byte[]> Sync(byte[] file, MimeType mimeType);
+		Task<ApiResponse> Sync(byte[] file, MimeType mimeType);
+
+		/// <summary>
+		/// Call the instant threat removal API.
+		/// </summary>
+		/// <param name="file">File to be converted to safe version</param>
+		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
+		/// <param name="risks">The risks that are or are not accessptable for the transformation</param>
+		/// <returns>The converted file returned from the Deep Secure Threat Removal API</returns>
+		Task<ApiResponse> Sync(byte[] file, MimeType mimeType, RiskOptions risks);
 	}
 }

--- a/src/DeepSecure.ThreatRemoval/Comms/Requester.cs
+++ b/src/DeepSecure.ThreatRemoval/Comms/Requester.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using DeepSecure.ThreatRemoval.Extensions;
 using DeepSecure.ThreatRemoval.Model;
@@ -15,20 +17,41 @@ namespace DeepSecure.ThreatRemoval.Comms
 	/// </summary>
 	public class Requester : IRequester
 	{
-		private static JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+		private static JsonSerializerOptions _serializerOptions = InitialiseSerialiserOptions();
+
+		private static JsonSerializerOptions InitialiseSerialiserOptions()
 		{
-			PropertyNameCaseInsensitive = true
-		};
-		private static IList<int> _acceptableNon200StatusCodes = new List<int>{400,429,500};
+			var options = new JsonSerializerOptions
+			{
+				PropertyNameCaseInsensitive = true,
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+			};
+			options.Converters.Add(new JsonStringEnumConverterWithAttributeSupport());
+
+			return options;
+		}
+
+		private static readonly string _risksTakenHeader = "X-Risks-Taken";
+		private static readonly IList<int> _acceptableNon200StatusCodes = new List<int>{400,429,500};
 		private readonly HttpClient _client;
 		private readonly IConfig _config;
 
+		/// <summary>
+		/// Create a new Requester instance for querying the Deep Secure API
+		/// </summary>
+		/// <param name="client"><c>HttpClient</c> if you want to provide your own in a wider application</param>
+		/// <param name="config"><c>IConfig</c> instance containing the parameters for the <c>Requester</c></param>
 		public Requester(HttpClient client, IConfig config)
 		{
 			_client = client;
 			_config = config;
 		}
 
+		/// <summary>
+		///Create a new Requester instance for querying the Deep Secure API
+		/// </summary>
+		/// <param name="config"><c>IConfig</c> instance containing the parameters for the <c>Requester</c></param>
+		/// <returns></returns>
 		public Requester(IConfig config) : this(new HttpClient(), config)
 		{
 
@@ -41,7 +64,20 @@ namespace DeepSecure.ThreatRemoval.Comms
 		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
 		/// <returns>The converted file returned from the Deep Secure Threat Removal API</returns>
 		/// <remarks>If the API returns a non-200 response then can throw either an <c>ApiRequestException</c> or <c>HttpRequestException</c></remarks>
-		public async Task<byte[]> Sync(byte[] file, MimeType mimeType)
+		public async Task<ApiResponse> Sync(byte[] file, MimeType mimeType)
+		{
+			return await Sync(file, mimeType, null).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Call the instant threat removal API.
+		/// </summary>
+		/// <param name="file">File to be converted to safe version</param>
+		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
+		/// <param name="risks">The <c>RiskOptions</c> for the request. See https://threat-removal.deep-secure.com/api/instant/documentation</param>
+		/// <returns>The converted file returned from the Deep Secure Threat Removal API</returns>
+		/// <remarks>If the API returns a non-200 response then can throw either an <c>ApiRequestException</c> or <c>HttpRequestException</c></remarks>
+		public async Task<ApiResponse> Sync(byte[] file, MimeType mimeType, RiskOptions risks)
 		{
 			var content = new ByteArrayContent(file);
 			content.Headers.ContentType = new MediaTypeHeaderValue(mimeType.GetStringValue());
@@ -55,6 +91,8 @@ namespace DeepSecure.ThreatRemoval.Comms
 				},
 				Content = content
 			};
+
+			AddXOptionsHeader(request, risks);
 
 			var response = await _client.SendAsync(request);
 
@@ -72,13 +110,55 @@ namespace DeepSecure.ThreatRemoval.Comms
 				}
 
 				var body = await response.Content.ReadAsStringAsync();
-				var apiResponse = JsonSerializer.Deserialize<ApiResponse>(body, _serializerOptions);
-				var apiErrorResponse = apiResponse.Error;
+				var restApiResponse = JsonSerializer.Deserialize<RestApiResponse>(body, _serializerOptions);
+				var apiErrorResponse = restApiResponse.Error;
 
 				throw new ApiRequestException(String.Format("API Request Failed with a {0} response.", statusCode), apiErrorResponse, ex);
 			}
 
-			return await response.Content.ReadAsByteArrayAsync();
+			var apiResponse = new ApiResponse {
+				File = await response.Content.ReadAsByteArrayAsync()
+			};
+
+			if (responseHasRisksTakenHeader(response))
+			{
+				addRisksTakenToApiResponse(apiResponse, response);
+			}
+
+			return apiResponse;
+		}
+
+		private void addRisksTakenToApiResponse(ApiResponse apiResponse, HttpResponseMessage response)
+		{
+			IEnumerable<string> values;
+			if (response.Headers.TryGetValues(_risksTakenHeader, out values))
+			{
+				var risksTaken = new List<Risk>();
+				values.First()
+					.Split(',', StringSplitOptions.RemoveEmptyEntries)
+					.ToList()
+					.ForEach(r => risksTaken.Add(r.ToEnum<Risk>()));
+				apiResponse.RisksTaken = risksTaken;
+			}
+		}
+
+		private bool responseHasRisksTakenHeader(HttpResponseMessage response)
+		{
+			return response.Headers.Contains(_risksTakenHeader);
+		}
+
+		private void AddXOptionsHeader(HttpRequestMessage request, RiskOptions risks)
+		{
+			if (risks == null)
+			{
+				return;
+			}
+
+			XOptionsHeader header = new XOptionsHeader{
+				Risks = risks
+			};
+
+			request.Content.Headers.Add("X-Options", JsonSerializer.Serialize<XOptionsHeader>(header, _serializerOptions));
 		}
 
 		private bool exceptionHasUnexpectedStatusCode(int statusCode)
@@ -86,9 +166,14 @@ namespace DeepSecure.ThreatRemoval.Comms
 			return _acceptableNon200StatusCodes.IndexOf(statusCode) == -1;
 		}
 
-		private class ApiResponse
+		private class RestApiResponse
 		{
 			public ApiErrorResponse Error { get; set; }
+		}
+
+		private class XOptionsHeader
+		{
+			public RiskOptions Risks { get; internal set; }
 		}
 	}
 }

--- a/src/DeepSecure.ThreatRemoval/ConvertFile.cs
+++ b/src/DeepSecure.ThreatRemoval/ConvertFile.cs
@@ -30,9 +30,23 @@ namespace DeepSecure.ThreatRemoval
 		/// <returns>The converted file with threats removed</returns>
 		public async Task<SyncResponse> Sync(byte[] file, MimeType mimeType)
 		{
-			var convertedFile = _requester.Sync(file, mimeType);
+			var response = await _requester.Sync(file, mimeType);
 
-			return new SyncResponse(await convertedFile);
+			return new SyncResponse(response.File, response.RisksTaken);
+		}
+
+		/// <summary>
+		/// Synchronously remove threats from a file
+		/// </summary>
+		/// <param name="file">File to be converted to safe version</param>
+		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
+		/// <param name="risks">The risks that are or are not accessptable for the transformation</param>
+		/// <returns>The converted file with threats removed</returns>
+		public async Task<SyncResponse> Sync(byte[] file, MimeType mimeType, RiskOptions risks)
+		{
+			var response = await _requester.Sync(file, mimeType, risks);
+			
+			return new SyncResponse(response.File, response.RisksTaken);
 		}
 	}
 }

--- a/src/DeepSecure.ThreatRemoval/DeepSecure.ThreatRemoval.csproj
+++ b/src/DeepSecure.ThreatRemoval/DeepSecure.ThreatRemoval.csproj
@@ -10,4 +10,8 @@
     <PackageTags>Threat Removal;File Cleansing</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="EnumExtensions.System.Text.Json" Version="1.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/DeepSecure.ThreatRemoval/Extensions/EnumExtension.cs
+++ b/src/DeepSecure.ThreatRemoval/Extensions/EnumExtension.cs
@@ -3,15 +3,34 @@ using DeepSecure.ThreatRemoval.Model;
 
 namespace DeepSecure.ThreatRemoval.Extensions
 {
-	internal static class EnumExtension
+	public static class EnumExtension
 	{
-		internal static string GetStringValue(this Enum value)
+		/// <summary>
+		/// Returns the <c>StringValue</c> attribute for this Enum
+		/// </summary>
+		public static string GetStringValue(this Enum value)
 		{
 			var type = value.GetType();
 			var fieldInfo = type.GetField(value.ToString());
 			var attributes = fieldInfo.GetCustomAttributes(typeof(StringValueAttribute), false) as StringValueAttribute[];
 
 			return attributes.Length > 0 ? attributes[0].StringValue : null;
+		}
+
+		/// <summary>
+		/// Converts a string the the matching enum
+		/// </summary>
+		public static T ToEnum<T>(this string str)
+		{
+			foreach (T item in Enum.GetValues(typeof(T)))
+			{
+				StringValueAttribute[] attributes = (StringValueAttribute[])item.GetType().GetField(item.ToString()).GetCustomAttributes(typeof(StringValueAttribute), false);
+				if ((attributes != null) && (attributes.Length > 0) && (attributes[0].StringValue.Equals(str)))
+				{
+					return item;
+				}
+			}
+			return (T)Enum.Parse(typeof(T), str, true);
 		}
 	}
 }

--- a/src/DeepSecure.ThreatRemoval/IConvertFile.cs
+++ b/src/DeepSecure.ThreatRemoval/IConvertFile.cs
@@ -16,5 +16,14 @@ namespace DeepSecure.ThreatRemoval
 		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
 		/// <returns>The converted file with threats removed</returns>
 		Task<SyncResponse> Sync(byte[] file, MimeType mimeType);
+
+		/// <summary>
+		/// Synchronously remove threats from a file
+		/// </summary>
+		/// <param name="file">File to be converted to safe version</param>
+		/// <param name="mimeType">The <c>MimeType</c> of the <c>file</c> parameter.</param>
+		/// <param name="risks">The risks that are or are not accessptable for the transformation</param>
+		/// <returns>The converted file with threats removed</returns>
+		Task<SyncResponse> Sync(byte[] file, MimeType mimeType, RiskOptions risks);
 	}
 }

--- a/src/DeepSecure.ThreatRemoval/Model/ApiResponse.cs
+++ b/src/DeepSecure.ThreatRemoval/Model/ApiResponse.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace DeepSecure.ThreatRemoval.Model
+{
+	/// <summary>
+	/// Model object to deserialise Deep Secure Threat Removal API
+	/// JSON responses into an object
+	/// </summary>
+	public class ApiResponse
+	{
+		/// <summary>
+		/// The converted file returned from the API
+		/// </summary>
+		public byte[] File { get; set; }
+		/// <summary>
+		/// The risks taken for this API request
+		/// </summary>
+		public IList<Risk> RisksTaken { get; set; }
+	}
+}

--- a/src/DeepSecure.ThreatRemoval/Model/IRiskOptions.cs
+++ b/src/DeepSecure.ThreatRemoval/Model/IRiskOptions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace DeepSecure.ThreatRemoval.Model
+{
+	/// <summary>
+	/// Risk options for the request see https://threat-removal.deep-secure.com/api/instant/documentation
+	/// </summary>
+	public interface IRiskOptions
+	{
+		/// <summary>
+		/// Set Allowed risks for request
+		/// </summary>
+		/// <value>Collection of risks</value>
+		IList<Risk> Allow { get; set; }
+
+		/// <summary>
+		/// Set Denied risks for request
+		/// </summary>
+		/// <value>Collection of risks</value>
+		IList<Risk> Deny { get; set; }
+	}
+}

--- a/src/DeepSecure.ThreatRemoval/Model/Risk.cs
+++ b/src/DeepSecure.ThreatRemoval/Model/Risk.cs
@@ -1,0 +1,56 @@
+using System.Runtime.Serialization;
+using DeepSecure.ThreatRemoval.Extensions;
+
+namespace DeepSecure.ThreatRemoval.Model
+{
+	/// <summary>
+	/// Risks that can be used with <c>RiskOptions</c> to configure
+	/// risk management for requests
+	/// </summary>
+	public enum Risk
+	{
+		[EnumMember(Value = "exe")]
+		[StringValue("exe")]
+		Exe,
+		[EnumMember(Value = "exe/macro")]
+		[StringValue("exe/macro")]
+		ExeMacro,
+		[EnumMember(Value = "exe/macro/ms")]
+		[StringValue("exe/macro/ms")]
+		ExeMacroMs,
+		[EnumMember(Value = "exe/macro/ms/word")]
+		[StringValue("exe/macro/ms/word")]
+		ExeMacroMsWord,
+		[EnumMember(Value = "exe/macro/ms/powerpoint")]
+		[StringValue("exe/macro/ms/powerpoint")]
+		ExeMacroMsPowerpoint,
+		[EnumMember(Value = "exe/macro/ms/excel")]
+		[StringValue("exe/macro/ms/excel")]
+		ExeMacroMsExcel,
+		[EnumMember(Value = "poly")]
+		[StringValue("poly")]
+		Poly,
+		[EnumMember(Value = "poly/text")]
+		[StringValue("poly/text")]
+		PolyText,
+		[EnumMember(Value = "poly/text/xml")]
+		[StringValue("poly/text/xml")]
+		PolyTextXml,
+		[EnumMember(Value = "poly/text/json")]
+		[StringValue("poly/text/json")]
+		PolyTextJson,
+		[EnumMember(Value = "structured")]
+		[StringValue("structured")]
+		Structured,
+		[EnumMember(Value = "structured/no-schema")]
+		[StringValue("structured/no-schema")]
+		StructuredNoSchema,
+		[EnumMember(Value = "structured/no-schema/xml")]
+		[StringValue("structured/no-schema/xml")]
+		StructuredNoSchemaXml,
+		[EnumMember(Value = "structured/no-schema/json")]
+		[StringValue("structured/no-schema/json")]
+		StructuredNoSchemaJson
+
+	}
+}

--- a/src/DeepSecure.ThreatRemoval/Model/RiskOptions.cs
+++ b/src/DeepSecure.ThreatRemoval/Model/RiskOptions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace DeepSecure.ThreatRemoval.Model
+{
+	/// <summary>
+	/// Risk options for the request see https://threat-removal.deep-secure.com/api/instant/documentation
+	/// </summary>
+	public class RiskOptions : IRiskOptions
+	{
+		/// <summary>
+		/// Set Allowed risks for request
+		/// </summary>
+		/// <value>Collection of risks</value>
+		public IList<Risk> Allow { get; set; }
+
+		/// <summary>
+		/// Set Denied risks for request
+		/// </summary>
+		/// <value>Collection of risks</value>
+		public IList<Risk> Deny { get; set; }
+	}
+}

--- a/src/DeepSecure.ThreatRemoval/Model/SyncResponse.cs
+++ b/src/DeepSecure.ThreatRemoval/Model/SyncResponse.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace DeepSecure.ThreatRemoval.Model
 {
 	/// <summary>
@@ -6,14 +8,24 @@ namespace DeepSecure.ThreatRemoval.Model
 	/// </summary>
 	public class SyncResponse
 	{
-		public SyncResponse(byte[] file)
+		/// <summary>
+		/// Response for synchronous file threat removal requests
+		/// </summary>
+		/// <param name="file">The file after threat removal</param>
+		/// <param name="risksTaken">Any risks taken when removing threats</param>
+		public SyncResponse(byte[] file, IList<Risk> risksTaken)
 		{
 			File = file;
+			RisksTaken = risksTaken;
 		}
 
 		/// <summary>
-		/// The file returned from the API
+		/// The file after threat removal
 		/// </summary>
 		public byte[] File { get; }
+		/// <summary>
+		/// Any risks taken when removing threats
+		/// </summary>
+		public IList<Risk> RisksTaken { get; }
 	}
 }

--- a/test/DeepSecure.ThreatRemoval.Test/Model/MimeTypeTest.cs
+++ b/test/DeepSecure.ThreatRemoval.Test/Model/MimeTypeTest.cs
@@ -1,0 +1,16 @@
+using DeepSecure.ThreatRemoval.Extensions;
+using DeepSecure.ThreatRemoval.Model;
+using NUnit.Framework;
+
+namespace DeepSecure.ThreatRemoval.Test.Model
+{
+	[TestFixture]
+	public class MimeTypeTest {
+		[Test]
+		public void ToEnum_WhenConvertingFromString_ThenReturnEnum()
+		{
+			var mimeType = "exe";
+			Assert.That(mimeType.ToEnum<Risk>(), Is.EqualTo(Risk.Exe));
+		}
+	}
+}


### PR DESCRIPTION
This adds support for both sending risks in the X-Options
header, and returning the X-Risks-Taken header in the
response

Closes #19